### PR TITLE
Chore/upgrade

### DIFF
--- a/.github/workflows/deploy-to-aws.yaml
+++ b/.github/workflows/deploy-to-aws.yaml
@@ -16,7 +16,7 @@ jobs:
 
   call-deploy-workflow:
     needs: call-test-workflow
-    uses: GNS-Science/nshm-github-actions/.github/workflows/deploy-to-aws.yml@main
+    uses: GNS-Science/nshm-github-actions/.github/workflows/deploy-to-aws-uv.yml@main
     with:
       python-version: '3.12'
       node-version: '22'

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,10 @@
 enableScripts: true
+
+npmMinimalAgeGate: "7d"
+
+npmPreapprovedPackages:
+  - "nshm-*"
+  - "nzshm-*"
+  - "solvis-*"
+  - "weka-*"
+  - "toshi-*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - migrate from poetry to uv
  - migrate to ruff
  - dependency upgrades
+ - deps: patch (koa 2.16.3→2.16.4, dicer 0.3.0→0.3.1); minor (lodash 4.17.23→4.18.1); major skipped: fast-xml-parser (s3rver compat)
 
 ## [0.10.0] - 2025-10-16
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "resolutions": {
     "@hapi/content": "6.0.1",
     "koa": "2.16.4",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "@smithy/config-resolver": "4.4.0",
     "brace-expansion": "2.0.3",
     "minimatch": "9.0.7",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
   "packageManager": "yarn@4.14.1",
   "resolutions": {
     "@hapi/content": "6.0.1",
-    "koa": "2.16.3",
+    "koa": "2.16.4",
     "lodash": "4.17.23",
     "@smithy/config-resolver": "4.4.0",
     "brace-expansion": "2.0.3",
     "minimatch": "9.0.7",
-    "fast-xml-parser": "4.1.2",
+    "s3rver/fast-xml-parser": "^3.21.1",
     "glob": "10.5.0",
-    "uuid": "14.0.0"
+    "uuid": "14.0.0",
+    "dicer": "0.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,10 +3033,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,12 +2240,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dicer@npm:0.3.0":
-  version: 0.3.0
-  resolution: "dicer@npm:0.3.0"
+"dicer@npm:0.3.1":
+  version: 0.3.1
+  resolution: "dicer@npm:0.3.1"
   dependencies:
-    streamsearch: "npm:0.1.2"
-  checksum: 10c0/4486f0448233145216cfadd5f6bbb4c26c3a28824da5344322b06051632e99d6af2b44f893fa8b30f1749ad175b4e565d301c760d0437226d9e41ccdb6546f35
+    streamsearch: "npm:^1.1.0"
+  checksum: 10c0/cb0bc25b6720ea4f9b9bd52a3e930bd1d70e5a673038f0994e3346d1fdd81222b98ac7b5007ca8c540fa41b9db3d50fb46197a399abf8caf5aab2c8ef7ce4c76
   languageName: node
   linkType: hard
 
@@ -2444,14 +2444,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:4.1.2":
-  version: 4.1.2
-  resolution: "fast-xml-parser@npm:4.1.2"
+"fast-xml-parser@npm:5.2.5":
+  version: 5.2.5
+  resolution: "fast-xml-parser@npm:5.2.5"
   dependencies:
-    strnum: "npm:^1.0.5"
+    strnum: "npm:^2.1.0"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/fdc599b28d6ff64ee3727209387cfbcfaa2c696bc8dca5e218876a6098b8df52c56fa899cc33b3ffc5ffa36de2ebbb308fe6794930b217e80dd5985fcab432bd
+  checksum: 10c0/d1057d2e790c327ccfc42b872b91786a4912a152d44f9507bf053f800102dfb07ece3da0a86b33ff6a0caa5a5cad86da3326744f6ae5efb0c6c571d754fe48cd
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^3.21.1":
+  version: 3.21.1
+  resolution: "fast-xml-parser@npm:3.21.1"
+  dependencies:
+    strnum: "npm:^1.0.4"
+  bin:
+    xml2js: cli.js
+  checksum: 10c0/26ed57fd3cb86434959cffa6852ab63231850ff5be6836aef7744b1abc8013fa5696c05179e422965677e116606611242d91ceebf246d91a5247e262d8b59996
   languageName: node
   linkType: hard
 
@@ -2975,9 +2986,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.16.3":
-  version: 2.16.3
-  resolution: "koa@npm:2.16.3"
+"koa@npm:2.16.4":
+  version: 2.16.4
+  resolution: "koa@npm:2.16.4"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -3002,7 +3013,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/43d614b3e044db9756108a2a8800811b00bc748a37632944412b78ccc336b74dabba4639d5664a978acca0185846dec9dac9792c4698059d35be3fc3520771a5
+  checksum: 10c0/bf21ffcf409bf847dca3f60349fc64a3b33e725e0ced3f405192a22fa51b4211cac29748f51df9674df82ca87691b3bdda64bbf80755ba6cdc6b2f35e878b0f5
   languageName: node
   linkType: hard
 
@@ -3668,10 +3679,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"streamsearch@npm:0.1.2":
-  version: 0.1.2
-  resolution: "streamsearch@npm:0.1.2"
-  checksum: 10c0/408a3db5b5643c1d6eb65c9d8ccc011b4857bfca41946d808b7f165b5b85f47755b2ff56ec1c4bbbeb5a496afcde9adfea12f9f67bd09ff3f04ae3f1f58d37c6
+"streamsearch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "streamsearch@npm:1.1.0"
+  checksum: 10c0/fbd9aecc2621364384d157f7e59426f4bfd385e8b424b5aaa79c83a6f5a1c8fd2e4e3289e95de1eb3511cb96bb333d6281a9919fafce760e4edb35b2cd2facab
   languageName: node
   linkType: hard
 
@@ -3740,10 +3751,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^1.0.5":
+"strnum@npm:^1.0.4":
   version: 1.1.2
   resolution: "strnum@npm:1.1.2"
   checksum: 10c0/a0fce2498fa3c64ce64a40dada41beb91cabe3caefa910e467dc0518ef2ebd7e4d10f8c2202a6104f1410254cae245066c0e94e2521fb4061a5cb41831952392
+  languageName: node
+  linkType: hard
+
+"strnum@npm:^2.1.0":
+  version: 2.2.3
+  resolution: "strnum@npm:2.2.3"
+  checksum: 10c0/1ee78101f1cd73a5b32f63cfd0be501bd246801a002f5987efef903a49e9297d1b63574e302ab3c06ee5e715c524d6cbdfef010e372ec1ea848e0179836cc208
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Running serverless failed. Serverless relies on `s3rver` which has no newer update and needs an old version of `fast-xml-parser` .

This PR was successfully deployed https://github.com/GNS-Science/kororaa-graphql-api/actions/runs/25148874443/job/73714800563

```

Run STAGE=test REGION=ap-southeast-2 yarn run deploy 2>&1 | tee deploy.out
Updating Serverless Framework...
✔ Installed Serverless Framework v4.34.0
Disable auto-updates by adding "frameworkVersion" to your serverless.yml (frameworkVersion: ~4.34.0)


✖ TypeError: xmlParser.parse is not a function
    at new S3ConfigBase (/home/runner/.yarn/berry/cache/s3rver-npm-3.7.1-66c067457f-10c0.zip/node_modules/s3rver/lib/models/config.js:41:32)
    at new TaggingConfiguration (/home/runner/.yarn/berry/cache/s3rver-npm-3.7.1-66c067457f-10c0.zip/node_modules/s3rver/lib/models/config.js:362:5)
    at Object.<anonymous> (/home/runner/.yarn/berry/cache/s3rver-npm-3.7.1-66c067457f-10c0.zip/node_modules/s3rver/lib/models/config.js:365:30)
    at Module._compile (node:internal/modules/cjs/loader:1705:14)
    at Object..js (node:internal/modules/cjs/loader:1838:10)
    at Module.load (node:internal/modules/cjs/loader:1441:32)
    at Function.<anonymous> (node:internal/modules/cjs/loader:1263:12)
    at require$$0.Module._load (/home/runner/work/kororaa-graphql-api/kororaa-graphql-api/.pnp.cjs:10310:31)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
    at Module.require (node:internal/modules/cjs/loader:1463:12)
    at require (node:internal/modules/helpers:147:16)
    at Object.<anonymous> (/home/runner/.yarn/berry/cache/s3rver-npm-3.7.1-66c067457f-10c0.zip/node_modules/s3rver/lib/s3rver.js:15:28)
    at Module._compile (node:internal/modules/cjs/loader:1705:14)
    at Object..js (node:internal/modules/cjs/loader:1838:10)
    at Module.load (node:internal/modules/cjs/loader:1441:32)

```

